### PR TITLE
Add Weather model and service parsing & API tests

### DIFF
--- a/lib/services/weather_service.dart
+++ b/lib/services/weather_service.dart
@@ -4,8 +4,17 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../models/weather_model.dart';
 
 class WeatherService {
-  final String? _apiKey = dotenv.env['OPENWEATHER_API_KEY'];
-  final String? _baseUrl = dotenv.env['OPENWEATHER_BASE_URL'];
+  final http.Client _client;
+  final String _apiKey;
+  final String _baseUrl;
+
+  WeatherService({
+    http.Client? client,
+    String? apiKey,
+    String? baseUrl,
+  })  : _client = client ?? http.Client(),
+        _apiKey = apiKey ?? (dotenv.env['OPENWEATHER_API_KEY'] ?? ''),
+        _baseUrl = baseUrl ?? (dotenv.env['OPENWEATHER_BASE_URL'] ?? '');
 
   // Anlık hava durumu
   Future<Weather> fetchWeather(String cityName) async {
@@ -13,7 +22,7 @@ class WeatherService {
       '$_baseUrl/weather?q=$cityName&appid=$_apiKey&units=metric&lang=en',
     );
 
-    final response = await http.get(url);
+    final response = await _client.get(url);
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
@@ -27,24 +36,33 @@ class WeatherService {
     }
   }
 
-  // 4 günlük tahmini veri
+  // 4 günlük tahmin
   Future<List<Weather>> fetchForecastByCity(String cityName) async {
     final url = Uri.parse(
       '$_baseUrl/forecast?q=$cityName&appid=$_apiKey&units=metric&lang=en',
     );
 
-    final response = await http.get(url);
+    final response = await _client.get(url);
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
       final List list = data['list'];
 
-      // Günde 8 veri geliyor, biz her 24 saatte bir olanları alıyoruz
-      final filtered = [list[0], list[8], list[16], list[24]];
-
-      return filtered.map((item) => Weather.fromForecastJson(item)).toList();
+      // 0, 8, 16, 24. indexleri al (3 saatlik veriden günde 8 adet var)
+      final indices = [0, 8, 16, 24].where((i) => i < list.length).toList();
+      return indices
+          .map<Weather>((i) => Weather.fromForecastJson(list[i]))
+          .toList();
+    } else if (response.statusCode == 401) {
+      throw Exception('API anahtarı geçersiz.');
+    } else if (response.statusCode == 404) {
+      throw Exception('Şehir bulunamadı: $cityName');
     } else {
       throw Exception('Forecast alınamadı: ${response.statusCode}');
     }
+  }
+
+  void dispose() {
+    _client.close();
   }
 }

--- a/test/models/weather_model_test.dart
+++ b/test/models/weather_model_test.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weather_app/models/weather_model.dart';
+
+void main() {
+  // Bu test, fromJson metodu ile normal JSON verisinin doğru okunup okunmadığını kontrol eder
+  test('Weather.fromJson → temel alanlar doğru parse edilir', () {
+    // API'den gelmiş gibi örnek JSON verisi
+    final map = {
+      "name": "Istanbul",
+      "weather": [
+        {"main": "Clear", "description": "clear sky", "icon": "01d"}
+      ],
+      "main": {"temp": 27, "feels_like": 28.2, "humidity": 40},
+      "wind": {"speed": 3}
+    };
+
+    // JSON verisini Weather nesnesine çevir
+    final w = Weather.fromJson(map);
+
+    // Beklediğimiz değerleri tek tek kontrol et
+    expect(w.cityName, 'Istanbul');
+    expect(w.main, 'Clear');
+    expect(w.description, 'clear sky');
+    expect(w.iconCode, '01d');
+    expect(w.temperature, 27.0);
+    expect(w.feelsLike, 28.2);
+    expect(w.humidity, 40);
+    expect(w.windSpeed, 3.0);
+    expect(w.date, isNull); // Burada tarih bilgisi yok
+  });
+
+  // Bu test, fromJson metodunun string JSON ile de çalışıp çalışmadığını kontrol eder
+  test('Weather.fromJson → JSON stringten de çalışır', () {
+    // JSON verisini string olarak yazdık
+    const s = '''
+    {"name":"Ankara",
+     "weather":[{"main":"Clouds","description":"broken clouds","icon":"04d"}],
+     "main":{"temp":22.5,"feels_like":22.9,"humidity":55},
+     "wind":{"speed":5.4}}
+    ''';
+
+    // String JSON'u önce decode edip sonra Weather nesnesine çevir
+    final w = Weather.fromJson(json.decode(s));
+
+    // Bazı alanların doğru olup olmadığını kontrol et
+    expect(w.cityName, 'Ankara');
+    expect(w.main, 'Clouds');
+    expect(w.temperature, 22.5);
+  });
+
+  // Bu test, fromForecastJson metodunun tahmin (forecast) verisini doğru okuyup okumadığını kontrol eder
+  test('Weather.fromForecastJson → dt_txt tarihini ve alanları okur', () {
+    // Tahmin verisi örneği
+    final map = {
+      "dt_txt": "2024-03-09 12:00:00",
+      "main": {"temp": 20, "feels_like": 20.3, "humidity": 60},
+      "weather": [{"main": "Rain", "description": "light rain", "icon": "10d"}],
+      "wind": {"speed": 2}
+    };
+
+    // Forecast JSON verisini Weather nesnesine çevir
+    final w = Weather.fromForecastJson(map);
+
+    // Alanların doğru olup olmadığını kontrol et
+    expect(w.cityName, isNull); // Forecast verisinde cityName yok
+    expect(w.main, 'Rain');
+    expect(w.description, 'light rain');
+    expect(w.iconCode, '10d');
+    expect(w.temperature, 20.0);
+    expect(w.feelsLike, 20.3);
+    expect(w.humidity, 60);
+    expect(w.windSpeed, 2.0);
+    expect(w.date, DateTime.parse("2024-03-09 12:00:00")); // Tarih stringten DateTime'a çevrilir
+  });
+}

--- a/test/services/weather_service_test.dart
+++ b/test/services/weather_service_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:weather_app/services/weather_service.dart';
+import 'package:weather_app/models/weather_model.dart';
+
+void main() {
+  // Testlerde kullanacağımız sahte base URL ve API key
+  const baseUrl = 'https://api.example.com';
+  const apiKey = 'KEY';
+
+  // Bu test, fetchWeather metodunun 200 (başarılı) cevabı doğru işleyip işlemediğini kontrol eder
+  test('fetchWeather → 200 başarılı olursa Weather döner', () async {
+    // MockClient ile sahte HTTP isteği tanımlıyoruz
+    final mockClient = MockClient((request) async {
+      // Doğru endpoint çağrılmış mı kontrol et
+      expect(request.url.path, '/weather');
+
+      // 200 durum kodu ile sahte JSON verisi döndür
+      return http.Response(jsonEncode({
+        "name": "Istanbul",
+        "weather": [
+          {"main": "Clear", "description": "clear sky", "icon": "01d"}
+        ],
+        "main": {"temp": 27, "feels_like": 28.2, "humidity": 40},
+        "wind": {"speed": 3}
+      }), 200, headers: {'content-type': 'application/json'});
+    });
+
+    // Servisi sahte client ile başlat
+    final service = WeatherService(client: mockClient, baseUrl: baseUrl, apiKey: apiKey);
+
+    // fetchWeather metodunu çağır
+    final w = await service.fetchWeather('Istanbul');
+
+    // Dönen veri Weather tipinde mi ve değerler doğru mu kontrol et
+    expect(w, isA<Weather>());
+    expect(w.main, 'Clear');
+    expect(w.temperature, 27.0);
+  });
+
+  // Bu test, fetchWeather metodunun 404 (bulunamadı) cevabında hata fırlatıp fırlatmadığını kontrol eder
+  test('fetchWeather → 404 olursa Exception fırlatır', () async {
+    // MockClient 404 dönecek şekilde ayarlandı
+    final mockClient = MockClient((_) async => http.Response('not found', 404));
+
+    // Servisi sahte client ile başlat
+    final service = WeatherService(client: mockClient, baseUrl: baseUrl, apiKey: apiKey);
+
+    // fetchWeather çağrıldığında hata fırlatmalı
+    expect(() => service.fetchWeather('NoCity'), throwsException);
+  });
+
+  // Bu test, fetchForecastByCity metodunun 200 cevabında 4 günlük tahmin listesini doğru döndürdüğünü kontrol eder
+  test('fetchForecastByCity → 200 olursa 4 kayıt döner (0,8,16,24)', () async {
+    // 25 öğelik sahte forecast listesi oluşturuyoruz (3 saatlik dilimlerle)
+    List<Map<String, dynamic>> list = List.generate(25, (i) {
+      final dt = DateTime(2024, 1, 1, 0).add(Duration(hours: 3 * i));
+      final dtTxt =
+          '${dt.year.toString().padLeft(4, '0')}-'
+          '${dt.month.toString().padLeft(2, '0')}-'
+          '${dt.day.toString().padLeft(2, '0')} '
+          '${dt.hour.toString().padLeft(2, '0')}:00:00';
+
+      return {
+        "dt": (dt.millisecondsSinceEpoch ~/ 1000),
+        "dt_txt": dtTxt,
+        "main": {
+          "temp": 20 + i.toDouble(),
+          "feels_like": 20 + i.toDouble(),
+          "humidity": 50
+        },
+        "weather": [
+          {"main": "Clouds", "description": "cloudy", "icon": "04d"}
+        ],
+        "wind": {"speed": 2}
+      };
+    });
+
+    // MockClient ile forecast endpoint'ine istek geldiğinde sahte listeyi döndür
+    final mockClient = MockClient((request) async {
+      expect(request.url.path, '/forecast');
+      return http.Response(jsonEncode({"cod": "200", "list": list}), 200,
+          headers: {'content-type': 'application/json'});
+    });
+
+    // Servisi sahte client ile başlat
+    final service = WeatherService(client: mockClient, baseUrl: baseUrl, apiKey: apiKey);
+
+    // Forecast verisini çek
+    final items = await service.fetchForecastByCity('Istanbul');
+
+    // 4 öğe dönmeli (0, 8, 16, 24. indexler)
+    expect(items.length, 4);
+    expect(items[0].temperature, 20.0); // index 0
+    expect(items[1].temperature, 28.0); // index 8 -> 20 + 8
+    expect(items[2].temperature, 36.0); // index 16
+    expect(items[3].temperature, 44.0); // index 24
+  });
+}


### PR DESCRIPTION
Bu PR ile Weather model ve WeatherService için birim testler eklendi.

1. Model testleri (test/models/weather_model_test.dart):

- fromJson ve fromForecastJson metotlarının JSON verilerini doğru parse ettiği test edildi.

2. Service testleri (test/services/weather_service_test.dart):

- fetchWeather metodu için 200 (başarılı) ve 404 (hata) senaryoları test edildi.

- fetchForecastByCity metodunun yalnızca 0, 8, 16 ve 24. indeksleri alarak 4 günlük tahmin döndürdüğü doğrulandı.

**Amaç:**
Model ve servis katmanındaki veri parse ve API yanıt işleme mantığının doğru çalıştığını garanti altına almak.


